### PR TITLE
Correctly handle the error by callback when uploading files to Qiniu.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function uploadBuf(uptoken, release, content, file, callback) {
 	qiniu.io.put(uptoken, objkey, content, extra, function(err, ret) {
 		if(err){
             console.log('error:', err);
+            callback(err);
         } else {
             var time = '[' + fis.log.now(true) + ']';
             process.stdout.write(


### PR DESCRIPTION
当调用七牛API上传出错时，应该扔出错误，让`fis release`失败。现在是默认忽略，release脚本会认为文件都上传成功，导致网站无法浏览因为七牛上缺失必须的资源。
